### PR TITLE
minimum knapsack

### DIFF
--- a/TEST/TEST_knapsack.cpp
+++ b/TEST/TEST_knapsack.cpp
@@ -75,6 +75,7 @@ void TEST_KNAPSACK(std::set<std::string> testset) {
         && compareAryUInt(result.items, result.numberOfItems, subset2, 5),
       "AAL_MINIMUM_KNAPSACK");
     free(subset2);
+    free(result.items);
   }
 
   free(instance.itemSizes);

--- a/TEST/TEST_knapsack.cpp
+++ b/TEST/TEST_knapsack.cpp
@@ -60,6 +60,22 @@ void TEST_KNAPSACK(std::set<std::string> testset) {
       "AAL_KNAPSACK_FPTAS");
     free(result.items);
   }
+  if (testset.count("FULL") != 0 || testset.count("AAL") != 0 || testset.count("KSM") != 0) {
+    unsigned int* subset2 = (unsigned int*) malloc(5 * sizeof(unsigned int));
+    subset2[0]            = 7;
+    subset2[1]            = 0;
+    subset2[2]            = 1;
+    subset2[3]            = 4;
+    subset2[4]            = 3;
+
+    AAL_knapsackResult result = AAL_knapsack_min(instance);
+
+    print_check(
+      std::abs(result.objectiveValue - 9.6f) < 0.00001f
+        && compareAryUInt(result.items, result.numberOfItems, subset2, 5),
+      "AAL_MINIMUM_KNAPSACK");
+    free(subset2);
+  }
 
   free(instance.itemSizes);
   free(instance.itemValues);

--- a/TEST/main.cpp
+++ b/TEST/main.cpp
@@ -29,6 +29,7 @@ void select_tests(int argc, char** argv) {
     std::cout << "-------------|---------|-------------------\n";
     std::cout << "     KSE     |   AAL   | knapsack exact\n";
     std::cout << "     KSF     |   AAL   | knapsack FPTAS\n";
+    std::cout << "     KSM     |   AAL   | minimum knapsack\n";
     std::cout << "     SCG     |   AAL   | setcover greedy\n";
     std::cout << "     TSN     |   AAL   | metric TSP nearest addition\n";
     std::cout << "     CHC     |   CGL   | convex hull chan\n";
@@ -36,7 +37,7 @@ void select_tests(int argc, char** argv) {
   }
 
   if (
-    testset.count("FULL") != 0 || testset.count("AAL") != 0 || testset.count("KSE") != 0 || testset.count("KSF") != 0) {
+    testset.count("FULL") != 0 || testset.count("AAL") != 0 || testset.count("KSE") != 0 || testset.count("KSF") != 0 || testset.count("KSM") != 0) {
     TEST_KNAPSACK(testset);
   }
   if (testset.count("FULL") != 0 || testset.count("AAL") != 0 || testset.count("SCG") != 0) {

--- a/src/AAL/AAL_knapsack.cpp
+++ b/src/AAL/AAL_knapsack.cpp
@@ -128,7 +128,7 @@ AAL_knapsackResult AAL_knapsack_min(const AAL_knapsackInstance instance) {
   for (unsigned int i = 0; i < instance.numberOfItems; ++i) {
     sizes[i]  = instance.itemSizes[i];
     values[i] = instance.itemValues[i];
-    if (values[i] == 0) {
+    if (values[i] == 0.0f) {
       zeros.push_back(i);  // keep track of zeros, because later will be divided by values
     }
   }
@@ -141,7 +141,7 @@ AAL_knapsackResult AAL_knapsack_min(const AAL_knapsackInstance instance) {
     A_complement.pop_back();
   }
 
-  float value = 0;
+  float value = 0.0f;
   while (value < instance.capacity) {
     if (A_complement.size() == 0) {
       throw std::logic_error("Minimum knapsack is infeasible on that instance!");
@@ -172,7 +172,7 @@ AAL_knapsackResult AAL_knapsack_min(const AAL_knapsackInstance instance) {
 
   // construct the solution
   unsigned int* items  = (unsigned int*) malloc(A.size() * sizeof(unsigned int));
-  float objectiveValue = 0;
+  float objectiveValue = 0.0f;
   for (unsigned int i = 0; i < A.size(); ++i) {
     objectiveValue += instance.itemSizes[A[i]];
     items[i] = A[i];

--- a/src/AAL/AAL_knapsack.h
+++ b/src/AAL/AAL_knapsack.h
@@ -20,8 +20,8 @@ extern "C" {
 /*!
  * \brief AAL_knapsack_exact solves the knapsack problem
  * \details Since the knapsack problem is solved to optimality this is not a polytime algorithm
- * \param instance
- * \return objective vaule and a list of the item contained in the optimal solution
+ * \param instance item sizes, item values, number of items and capacity which specify the problem
+ * \return objective value and a list of the item contained in the optimal solution
  */
 AAL_knapsackResult AAL_knapsack_exact(const AAL_knapsackInstance instance);
 
@@ -29,9 +29,17 @@ AAL_knapsackResult AAL_knapsack_exact(const AAL_knapsackInstance instance);
  * \brief AAL_knapsack_fptas approximates the knapsack problem
  * \param instance item sizes, item values, number of items and capacity which specify the problem
  * \param eps factor for the approximation guarantee, objective value will be at least (1 - eps) OPT
- * \return objective value returned by the exact algorithm on the rounded data
+ * \return objective value (based on original itemvalues) and item list of the rounded instance
  */
 AAL_knapsackResult AAL_knapsack_fptas(const AAL_knapsackInstance instance, const float eps);
+
+/*!
+ * \brief AAL_knapsack_min
+ * \param instance item sizes, item values, number of items and capacity which specify the problem
+ * \details 2 approximation algorithm using the primal-dual method, for n items runtime is O(n)
+ * \return objective value and a list of the items conatined in the approximated solution
+ */
+AAL_knapsackResult AAL_knapsack_min(const AAL_knapsackInstance instance);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is the first algorithm in where we could enter the case of an infeasible instance.
Do you think we should introduce own error types for that purpose inheriting from the errors from `std::except`?